### PR TITLE
Force async method for step decorator

### DIFF
--- a/.changeset/sweet-llamas-decide.md
+++ b/.changeset/sweet-llamas-decide.md
@@ -1,0 +1,5 @@
+---
+"@cerios/playwright-step-decorator": minor
+---
+
+force async methods to be used with step decorator to prevent unawaited async

--- a/.changeset/sweet-llamas-decide.md
+++ b/.changeset/sweet-llamas-decide.md
@@ -1,5 +1,0 @@
----
-"@cerios/playwright-step-decorator": minor
----
-
-force async methods to be used with step decorator to prevent unawaited async

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @cerios/playwright-step-decorator
 
+## 1.3.0
+
+### Minor Changes
+
+- 969a029: force async methods to be used with step decorator to prevent unawaited async
+
 ## 1.2.0
 
 ### Minor Changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@cerios/playwright-step-decorator",
-	"version": "1.2.0",
+	"version": "1.3.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@cerios/playwright-step-decorator",
-			"version": "1.2.0",
+			"version": "1.3.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@arethetypeswrong/cli": "^0.18.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@cerios/playwright-step-decorator",
-	"version": "1.2.0",
+	"version": "1.3.0",
 	"author": "Ronald Veth - Cerios",
 	"description": "A Playwright decorator for creating step-based tests",
 	"license": "MIT",


### PR DESCRIPTION
Now forced to use async methods with a @step decorator, because when using sync methods the call cannot be awaited